### PR TITLE
Update namespaces for PiggyCustomEnchants, bump to v5.2.4

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: AdvancedKits
 main: AdvancedKits\Main
-version: 5.2.3
+version: 5.2.4
 api: [3.0.0]
 author: luca28pet
 description: Add kits to your server

--- a/src/AdvancedKits/Kit.php
+++ b/src/AdvancedKits/Kit.php
@@ -218,7 +218,7 @@ class Kit{
                 $enchantment = Enchantment::getEnchantmentByName($enchantmentsData[0]);
                 if($enchantment === null){ //If the specified enchantment is not a vanilla enchantment
                     if($this->ak->piggyCustomEnchantsInstance !== null){ //Check if PiggyCustomEnchants is loaded and try to load the enchantment from there
-                        $enchantment = \PiggyCustomEnchants\CustomEnchants\CustomEnchants::getEnchantmentByName($enchantmentsData[0]);
+                        $enchantment = \DaPigGuy\PiggyCustomEnchants\CustomEnchants\CustomEnchants::getEnchantmentByName($enchantmentsData[0]);
                         if($enchantment === null){ //If the specified enchantment is not a custom enchantment
                             $this->ak->getLogger()->warning('Bad configuration in kit '.$this->name.'. Enchantment '.$enchantmentsData[0].' in item '.$itemString.' could not be loaded because the enchantment does not exist');
                             continue;
@@ -234,7 +234,7 @@ class Kit{
                     continue;
                 }
 
-                if($this->ak->piggyCustomEnchantsInstance !== null && $enchantment instanceof \PiggyCustomEnchants\CustomEnchants\CustomEnchants){
+                if($this->ak->piggyCustomEnchantsInstance !== null && $enchantment instanceof \DaPigGuy\PiggyCustomEnchants\CustomEnchants\CustomEnchants){
                     $this->ak->piggyCustomEnchantsInstance->addEnchantment($item, [$enchantmentsData[0]], [(int) $enchantmentsData[1]]);
                 }else{
                     $item->addEnchantment(new EnchantmentInstance($enchantment, (int) $enchantmentsData[1]));

--- a/src/AdvancedKits/Main.php
+++ b/src/AdvancedKits/Main.php
@@ -22,7 +22,7 @@ class Main extends PluginBase{
     public $permManager;
     /** @var LangManager */
     public $langManager;
-    /** @var  null|\PiggyCustomEnchants\Main */
+    /** @var  null|\DaPigGuy\PiggyCustomEnchants\Main */
     public $piggyCustomEnchantsInstance;
     /** @var  null|\jojoe77777\FormAPI\FormAPI */
     public $formAPIInstance;


### PR DESCRIPTION
As of https://github.com/DaPigGuy/PiggyCustomEnchants/commit/15b6e01660ea3c3c0f7b6614412739b2efe1d60c, the namespaces of PiggyCustomEnchants have been refactored from `PiggyCustomEnchants\Main` to `DaPigGuy\PiggyCustomEnchants\Main` in order to comply with Poggit C1a rule.

Sorry for the inconvenience this may have caused.